### PR TITLE
convert to Test::Deep

### DIFF
--- a/t/10-basics.t
+++ b/t/10-basics.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More 0.88;
-use Test::Differences;
+use Test::Deep;
 
 use CPAN::Meta;
 use CPAN::Meta::Check qw/check_requirements verify_dependencies/;
@@ -31,14 +31,14 @@ my %prereq_struct = (
 
 my $meta = CPAN::Meta->create({ prereqs => \%prereq_struct, version => 1, name => 'Foo'  }, { lazy_validation => 1 });
 
-eq_or_diff([ verify_dependencies($meta, 'runtime', 'requires') ], [], 'Requirements are verified');
+cmp_deeply([ verify_dependencies($meta, 'runtime', 'requires') ], [], 'Requirements are verified');
 
 my $pre_req = $meta->effective_prereqs->requirements_for('runtime', 'requires');
 is($pre_req->required_modules, 4, 'Requires 4 modules');
-eq_or_diff(check_requirements($pre_req, 'requires'), { map { ( $_ => undef ) } qw/Config File::Spec IO::File perl/ }, 'Requirements are satisfied ');
+cmp_deeply(check_requirements($pre_req, 'requires'), { map { ( $_ => undef ) } qw/Config File::Spec IO::File perl/ }, 'Requirements are satisfied ');
 
 my $pre_rec = $meta->effective_prereqs->requirements_for('runtime', 'recommends');
-eq_or_diff([ sort +$pre_rec->required_modules ], [ qw/Carp Pod::Text This::Should::Be::NonExistent/ ], 'The right recommendations are present');
-eq_or_diff(check_requirements($pre_rec, 'recommends'), { Carp => "Installed version ($Carp::VERSION) of Carp is not in range '99999'", 'Pod::Text' => undef, 'This::Should::Be::NonExistent' => 'Module \'This::Should::Be::NonExistent\' is not installed' }, 'Recommendations give the right errors');
+cmp_deeply([ sort +$pre_rec->required_modules ], [ qw/Carp Pod::Text This::Should::Be::NonExistent/ ], 'The right recommendations are present');
+cmp_deeply(check_requirements($pre_rec, 'recommends'), { Carp => "Installed version ($Carp::VERSION) of Carp is not in range '99999'", 'Pod::Text' => undef, 'This::Should::Be::NonExistent' => 'Module \'This::Should::Be::NonExistent\' is not installed' }, 'Recommendations give the right errors');
 
 done_testing();


### PR DESCRIPTION
Test::Differences is not as well maintained as Test::Deep, and it is currently broken with Test::Builder 1.005+/TB2.  This is a simple patch to switch to Test::Deep so as to allow a big tree of dependencies to build once again in the presence of TB2.
