### PR TITLE
Tbsliver/undef fix

### DIFF
--- a/lib/CPAN/Meta/Check.pm
+++ b/lib/CPAN/Meta/Check.pm
@@ -43,7 +43,7 @@ sub check_requirements {
 	my ($reqs, $type, $dirs) = @_;
 
 	my %ret;
-	if (($type||'') ne 'conflicts') {
+	if (($type||'runtime') ne 'conflicts') {
 		for my $module ($reqs->required_modules) {
 			$ret{$module} = _check_dep($reqs, $module, $dirs);
 		}


### PR DESCRIPTION
These changes are as discussed in IRC, to allow the check_requirements function to be called with an undef type as it is only checked against one equality.
