### PR TITLE
Remove specific version 2.120920 from use

### DIFF
--- a/lib/CPAN/Meta/Check.pm
+++ b/lib/CPAN/Meta/Check.pm
@@ -7,7 +7,7 @@ our @EXPORT = qw//;
 our @EXPORT_OK = qw/check_requirements requirements_for verify_dependencies/;
 our %EXPORT_TAGS = (all => [ @EXPORT, @EXPORT_OK ] );
 
-use CPAN::Meta::Requirements 2.120920;
+use CPAN::Meta::Requirements;
 use Module::Metadata;
 
 sub _check_dep {


### PR DESCRIPTION
Removed specific version from use statement 'use CPAN::Meta::Requirements 2.120920;' as higher version requirement already specified in dist.ini file which is 2.121. 
If we don't do this it will create problems while using cpanspec to package module.
