### PR TITLE
bump MMD prereq to parse newer $VERSION syntax

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for CPAN-Meta-Check
 
 {{$NEXT}}
+          bump Module::Metdata prereq for $VERSION parsing (RT#101095)
 
 0.009     2014-06-20 19:37:43+02:00 Europe/Amsterdam
           Various POD fixes

--- a/lib/CPAN/Meta/Check.pm
+++ b/lib/CPAN/Meta/Check.pm
@@ -42,18 +42,13 @@ sub requirements_for {
 sub check_requirements {
 	my ($reqs, $type, $dirs) = @_;
 
-	my %ret;
-	if ($type ne 'conflicts') {
-		for my $module ($reqs->required_modules) {
-			$ret{$module} = _check_dep($reqs, $module, $dirs);
-		}
-	}
-	else {
-		for my $module ($reqs->required_modules) {
-			$ret{$module} = _check_conflict($reqs, $module, $dirs);
-		}
-	}
-	return \%ret;
+	return +{
+		map {
+			$_ => $type ne 'conflicts'
+				? _check_dep($reqs, $_, $dirs)
+				: _check_conflict($reqs, $_, $dirs)
+		} $reqs->required_modules
+	};
 }
 
 sub verify_dependencies {

--- a/lib/CPAN/Meta/Check.pm
+++ b/lib/CPAN/Meta/Check.pm
@@ -8,7 +8,7 @@ our @EXPORT_OK = qw/check_requirements requirements_for verify_dependencies/;
 our %EXPORT_TAGS = (all => [ @EXPORT, @EXPORT_OK ] );
 
 use CPAN::Meta::Requirements 2.120920;
-use Module::Metadata;
+use Module::Metadata 1.000023;
 
 sub _check_dep {
 	my ($reqs, $module, $dirs) = @_;

--- a/lib/CPAN/Meta/Check.pm
+++ b/lib/CPAN/Meta/Check.pm
@@ -63,7 +63,6 @@ sub verify_dependencies {
 	return grep { defined } values %{ $issues };
 }
 
-# vi:noet:sts=2:sw=2:ts=2
 1;
 
 #ABSTRACT: Verify requirements in a CPAN::Meta object
@@ -99,5 +98,8 @@ This function returns a unified L<CPAN::Meta::Requirements|CPAN::Meta::Requireme
 =item * L<Test::CheckDeps|Test::CheckDeps>
 
 =item * L<CPAN::Meta|CPAN::Meta>
+
+=for comment
+# vi:noet:sts=2:sw=2:ts=2
 
 =back


### PR DESCRIPTION
https://rt.cpan.org/Ticket/Update.html?id=101095 for details -- bump prereq to ensure this syntax is parsable

Also includes a modeline fix, and an edit I had in a stash for quite a while that simply shortens the code a bit.