### PR TITLE
declare the minimum version required for the "merged_requirements" interface

### DIFF
--- a/lib/CPAN/Meta/Check.pm
+++ b/lib/CPAN/Meta/Check.pm
@@ -7,6 +7,7 @@ our @EXPORT = qw//;
 our @EXPORT_OK = qw/check_requirements requirements_for verify_dependencies/;
 our %EXPORT_TAGS = (all => [ @EXPORT, @EXPORT_OK ] );
 
+use CPAN::Meta::Prereqs '2.132830';
 use CPAN::Meta::Requirements 2.121;
 use Module::Metadata 1.000023;
 


### PR DESCRIPTION
After noticing tests failing when installing into an older perl...