### PR TITLE
Handle undef versions like any other

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for CPAN-Meta-Check
 
 {{$NEXT}}
+          Undef versions are now passed through to CPAN::Meta::Requirements
+          for the check, rather than failing with "Missing version" errors.
 
 0.013     2016-07-20 22:26:07+02:00 Europe/Amsterdam
           Make tests more resilient against dev versions of dependencies

--- a/lib/CPAN/Meta/Check.pm
+++ b/lib/CPAN/Meta/Check.pm
@@ -19,9 +19,11 @@ sub _check_dep {
 
 	my $metadata = Module::Metadata->new_from_module($module, inc => $dirs);
 	return "Module '$module' is not installed" if not defined $metadata;
+
 	my $version = eval { $metadata->version };
-	return "Missing version info for module '$module'" if $reqs->requirements_for_module($module) and not $version;
-	return sprintf 'Installed version (%s) of %s is not in range \'%s\'', $version, $module, $reqs->requirements_for_module($module) if not $reqs->accepts_module($module, $version || 0);
+	return sprintf 'Installed version (%s) of %s is not in range \'%s\'',
+			(defined $version ? $version : 'undef'), $module, $reqs->requirements_for_module($module)
+		if not $reqs->accepts_module($module, $version || 0);
 	return;
 }
 
@@ -29,9 +31,11 @@ sub _check_conflict {
 	my ($reqs, $module, $dirs) = @_;
 	my $metadata = Module::Metadata->new_from_module($module, inc => $dirs);
 	return if not defined $metadata;
+
 	my $version = eval { $metadata->version };
-	return "Missing version info for module '$module'" if not $version;
-	return sprintf 'Installed version (%s) of %s is in range \'%s\'', $version, $module, $reqs->requirements_for_module($module) if $reqs->accepts_module($module, $version);
+	return sprintf 'Installed version (%s) of %s is in range \'%s\'',
+			(defined $version ? $version : 'undef'), $module, $reqs->requirements_for_module($module)
+		if $reqs->accepts_module($module, $version);
 	return;
 }
 

--- a/t/20-undef-version.t
+++ b/t/20-undef-version.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use Test::Deep;
+use CPAN::Meta 2.120920;
+use CPAN::Meta::Check 'check_requirements';
+
+use lib 't/lib';
+
+my %prereq_struct = (
+	runtime => {
+		requires => {
+			'Local::HasNoVersion'	=> '!= 1.0',	# check should pass
+		},
+		conflicts => {
+			'Local::HasNoVersion' => '>= 1.0',	# check should pass
+		},
+	},
+	test => {
+		requires => {
+			'Local::HasNoVersion'	=> '== 1.0',	# check should fail
+		},
+		conflicts => {
+			'Local::HasNoVersion' => '<= 1.0',	# check should fail
+		},
+	},
+);
+
+my %expected_issues = (
+	runtime => {
+		conflicts => { 'Local::HasNoVersion' => undef },
+		requires => { 'Local::HasNoVersion' => undef },
+	},
+	test => {
+		conflicts => { 'Local::HasNoVersion' => re(qr/Installed version \(undef\) of Local::HasNoVersion is in range '<= 1.0'/) },
+		requires => { 'Local::HasNoVersion' => re(qr/Installed version \(undef\) of Local::HasNoVersion is not in range '== 1.0'/) },
+	},
+);
+
+my $meta = CPAN::Meta->create({ prereqs => \%prereq_struct, version => 1, name => 'Foo'  }, { lazy_validation => 1 });
+
+foreach my $phase (sort keys %expected_issues) {
+	foreach my $type (sort keys %{$expected_issues{$phase}}) {
+		my $issues = check_requirements($meta->effective_prereqs->requirements_for($phase, $type), $type, ['t/lib']);
+		cmp_deeply(
+			$issues,
+			$expected_issues{$phase}{$type},
+			"$phase $type checked",
+		)
+			or diag 'CPAN::Meta::Check returned: ', explain $issues;
+	}
+}
+
+done_testing;
+# vi:noet:sts=2:sw=2:ts=2

--- a/t/lib/Local/HasNoVersion.pm
+++ b/t/lib/Local/HasNoVersion.pm
@@ -1,0 +1,3 @@
+package Local::HasNoVersion;
+# no $VERSION declaration implies undef
+1;


### PR DESCRIPTION
I noticed, via Dist::Zilla::Plugin::Test::CheckBreaks, that modules with no $VERSION were being treated differently than a version of 0, and certain checks such as "version must be <= 1.0" were failing when they should have passed.  This change just passes undef versions through to CPAN::Meta::Requirements for it to verify against the prereq data, like any other, rather than erroring early.
